### PR TITLE
CEDGE-603 Optimize query content: private network address processing.

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -478,7 +478,7 @@ Specifies the maximum number of hops (max time-to-live value) traceroute will
 probe.  Default is 30.
 .TP
 .B \-U \fINUM\fR, \fB\-\-max-unknown \fINUM
-Specifies the maximum unknown host. Default is 5.
+Specifies the maximum unknown host. Default is 12.
 .TP
 .B \-u\fR, \fB\-\-udp
 Use UDP datagrams instead of ICMP ECHO.

--- a/ui/asn.h
+++ b/ui/asn.h
@@ -37,7 +37,8 @@ extern void asn_close(
     struct mtr_ctl *ctl);
 extern char *fmt_ipinfo(
     struct mtr_ctl *ctl,
-    ip_t * addr);
+    ip_t * addr,
+    int hops);
 extern ATTRIBUTE_CONST size_t get_iiwidth_len(
     void);
 extern ATTRIBUTE_CONST int get_iiwidth(
@@ -49,9 +50,11 @@ extern int is_printii(
 extern char *ipinfo_get_content(
     struct mtr_ctl *ctl,
     ip_t * addr,
-    int ipinfo_index);
+    int ipinfo_index,
+    int hops);
 extern int get_ipinfo_compose(
     struct mtr_ctl *ctl,
     ip_t *addr,
     char *buf,
-    int buflen);
+    int buflen,
+    int hops);

--- a/ui/curses.c
+++ b/ui/curses.c
@@ -129,7 +129,7 @@ int mtr_curses_keyaction(
     struct mtr_ctl *ctl)
 {
     int c = getch();
-    int i = 0, j, k;
+    int i = 0, j;
     int offset;
     float f = 0.0;
     char buf[MAXFLD + 1];
@@ -284,8 +284,7 @@ int mtr_curses_keyaction(
         return ActionNone;
         /* fields to display & their ordering */
     case 'o':
-        //mvprintw(2, 0, "Fields: %s\n\n", ctl->fld_active);
-        mvprintw(2, 0, "Fields: \n\n");
+        mvprintw(2, 0, "Fields: %s\n\n", ctl->fld_active);
 
         printw("  WARN: The field order of IPINFO will be automatically adjusted in the front and in order\n\n");
         for (i = 0; i < MAXFLD; i++) {
@@ -312,16 +311,20 @@ int mtr_curses_keyaction(
 
         ctl->ipinfo_arr = 0;
         ctl->ipinfo_no = -1;
-        for (i = 0, j = 0, k = 0; buf[i]; i++) {
+        for (i = 0, j = 0; buf[i]; i++) {
             if (is_ipinfo_filed(buf[i])) {
                 ctl->ipinfo_arr |= (1 << ipinfo_key2no(buf[i]));
-                fld_ipinfo[k++] = buf[i];
                 continue;
             }
             fld_tmp[j++] = buf[i];
         }
         if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
             ctl->ipinfo_no = (int)log2(ctl->ipinfo_arr & (0 - ctl->ipinfo_arr));
+        }
+        for (i = 0, j = 0; i < IPINFO_NUMS; i++) {
+            if (IS_INDEX_IPINFO(ctl->ipinfo_arr, i)) {
+                fld_ipinfo[j++] = ipinfo_no2key(i);
+            }
         }
         strcat(fld_ipinfo, fld_tmp);
         if (strlen(fld_ipinfo) > 0)
@@ -376,7 +379,7 @@ int mtr_curses_keyaction(
             ("  o str   set the columns to display, default str='LRS N BAWV'\n");
         printw
             ("  j       toggle latency(LS NABWV)/jitter(DR AGJMXI) stats\n");
-        printw("  c <n>   report cycle n, default n=infinite\n");
+        //printw("  c <n>   report cycle n, default n=infinite\n");
         printw
             ("  i <n>   set the ping interval to n seconds, default n=1\n");
         printw
@@ -388,6 +391,7 @@ int mtr_curses_keyaction(
             ("  b <c>   set ping bit pattern to c(0..255) or random(c<0)\n");
         printw("  Q <t>   set ping packet's TOS to t\n");
         printw("  u       switch between ICMP ECHO and UDP datagrams\n");
+        printw("  t       switch between ICMP ECHO and TCP datagrams\n");
 #ifdef HAVE_IPINFO
         printw("  y       switching IP info\n");
         printw("  z       toggle ASN info on/off\n");
@@ -457,7 +461,7 @@ static void mtr_curses_hosts(
                 attron(A_BOLD);
 
 #ifdef HAVE_IPINFO
-            i = get_ipinfo_compose(ctl, addr, buf, sizeof(buf));
+            i = get_ipinfo_compose(ctl, addr, buf, sizeof(buf), at+1);
             printw("%s", buf);
 #endif
 
@@ -513,7 +517,7 @@ static void mtr_curses_hosts(
                     attron(A_BOLD);
                 printw("\n    ");
 #ifdef HAVE_IPINFO
-                get_ipinfo_compose(ctl, addr, buf, sizeof(buf));
+                get_ipinfo_compose(ctl, addrs, buf, sizeof(buf), at+1);
                 printw("%s", buf);
 #endif
                 if (name != NULL) {
@@ -679,7 +683,7 @@ static void mtr_curses_graph(
 
 #ifdef HAVE_IPINFO
             char buf[1024];
-            get_ipinfo_compose(ctl, addr, buf, sizeof(buf));
+            get_ipinfo_compose(ctl, addr, buf, sizeof(buf), at+1);
             printw("%s", buf);
 #endif
             name = dns_lookup(ctl, addr);

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -533,7 +533,7 @@ static void update_tree_row(
     char buf[1024];
 
     if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
-        get_ipinfo_compose(ctl, addr, buf, sizeof(buf));
+        get_ipinfo_compose(ctl, addr, buf, sizeof(buf), row+1);
         gtk_list_store_set(ReportStore, iter, COL_ASN, buf, -1);
     }
 #endif

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -157,87 +157,94 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs("\nUsage:\n", out);
     fputs(" mtr [options] hostname\n", out);
     fputs("\n", out);
-    fputs(" -F, --filename FILE        read hostname(s) from a file\n",
+    fputs(" -F, --filename FILE            read hostname(s) from a file\n",
           out);
-    fputs(" -4                         use IPv4 only\n", out);
+    fputs(" -4                             use IPv4 only\n", out);
 #ifdef ENABLE_IPV6
-    fputs(" -6                         use IPv6 only\n", out);
+    fputs(" -6                             use IPv6 only\n", out);
 #endif
-    fputs(" -u, --udp                  use UDP instead of ICMP echo\n",
+    fputs(" -u, --udp                      use UDP instead of ICMP echo\n",
           out);
-    fputs(" -T, --tcp                  use TCP instead of ICMP echo\n",
+    fputs(" -T, --tcp                      use TCP instead of ICMP echo\n",
           out);
-    fputs(" -I, --interface NAME       use named network interface\n",
+    fputs(" -I, --interface NAME           use named network interface\n",
          out);
     fputs
-        (" -a, --address ADDRESS      bind the outgoing socket to ADDRESS\n",
+        (" -a, --address ADDRESS          bind the outgoing socket to ADDRESS\n",
          out);
-    fputs(" -f, --first-ttl NUMBER     set what TTL to start\n", out);
-    fputs(" -m, --max-ttl NUMBER       maximum number of hops\n", out);
-    fputs(" -U, --max-unknown NUMBER   maximum unknown host\n", out);
+    fputs(" -f, --first-ttl NUMBER         set what TTL to start\n", out);
+    fputs(" -m, --max-ttl NUMBER           maximum number of hops\n", out);
+    fputs(" -U, --max-unknown NUMBER       maximum unknown host\n", out);
     fputs
-        (" -P, --port PORT            target port number for TCP, SCTP, or UDP\n",
+        (" -P, --port PORT                target port number for TCP, SCTP, or UDP\n",
          out);
-    fputs(" -L, --localport LOCALPORT  source port number for UDP\n", out);
+    fputs(" -L, --localport LOCALPORT      source port number for UDP\n", out);
     fputs
-        (" -s, --psize PACKETSIZE     set the packet size used for probing\n",
-         out);
-    fputs
-        (" -B, --bitpattern NUMBER    set bit pattern to use in payload\n",
-         out);
-    fputs(" -i, --interval SECONDS     ICMP echo request interval\n", out);
-    fputs
-        (" -Q, --tos NUMBER           type of service field in IP header\n",
+        (" -s, --psize PACKETSIZE         set the packet size used for probing\n",
          out);
     fputs
-        (" -e, --mpls                 display information from ICMP extensions\n",
+        (" -B, --bitpattern NUMBER        set bit pattern to use in payload\n",
+         out);
+    fputs(" -i, --interval SECONDS         ICMP echo request interval\n", out);
+    fputs
+        (" -Q, --tos NUMBER               type of service field in IP header\n",
          out);
     fputs
-        (" -Z, --timeout SECONDS      seconds to wait for a probe response\n",
+        (" -e, --mpls                     display information from ICMP extensions\n",
+         out);
+    fputs
+        (" -Z, --timeout SECONDS          seconds to wait for a probe response\n",
          out);
 #ifdef SO_MARK
-    fputs(" -M, --mark MARK            mark each sent packet\n", out);
+    fputs(" -M, --mark MARK                mark each sent packet\n", out);
 #endif
-    fputs(" -r, --report               output using report mode\n", out);
-    fputs(" -w, --report-wide          output wide report\n", out);
-    fputs(" -c, --report-cycles COUNT  set the number of pings sent\n",
+    fputs(" -r, --report                   output using report mode\n", out);
+    fputs(" -w, --report-wide              output wide report\n", out);
+    fputs(" -c, --report-cycles COUNT      set the number of pings sent\n",
           out);
-    fputs(" -j, --json                 output json\n", out);
-    fputs(" -x, --xml                  output xml\n", out);
-    fputs(" -C, --csv                  output comma separated values\n",
+    fputs(" -j, --json                     output json\n", out);
+    fputs(" -x, --xml                      output xml\n", out);
+    fputs(" -C, --csv                      output comma separated values\n",
           out);
-    fputs(" -l, --raw                  output raw format\n", out);
-    fputs(" -p, --split                split output\n", out);
+    fputs(" -l, --raw                      output raw format\n", out);
+    fputs(" -p, --split                    split output\n", out);
 #ifdef HAVE_CURSES
-    fputs(" -t, --curses               use curses terminal interface\n",
+    fputs(" -t, --curses                   use curses terminal interface\n",
           out);
 #endif
-    fputs("     --displaymode MODE     select initial display mode\n",
+    fputs("     --displaymode MODE         select initial display mode\n",
           out);
 #ifdef HAVE_GTK
-    fputs(" -g, --gtk                  use GTK+ xwindow interface\n", out);
+    fputs(" -g, --gtk                      use GTK+ xwindow interface\n", out);
 #endif
-    fputs(" -n, --no-dns               do not resolve host names\n", out);
-    fputs(" -b, --show-ips             show IP numbers and host names\n",
+    fputs(" -n, --no-dns                   do not resolve host names\n", out);
+    fputs(" -b, --show-ips                 show IP numbers and host names\n",
           out);
-    fputs(" -o, --order FIELDS         select output fields\n", out);
+    fputs(" -o, --order FIELDS             select output fields\n", out);
 #ifdef HAVE_IPINFO
-    fputs(" -y, --ipinfo NUMBER,……     select IP information in output\n",
-          out);
-    fputs(" --ipinfo-asn               display AS number\n", out);
-    fputs(" --ipinfo-ip-prefix         display IP prefix\n", out);
-    fputs(" --ipinfo-country           display country code\n", out);
-    fputs(" --ipinfo-register          display register\n", out);
-    fputs(" --ipinfo-date              display allocation date\n", out);
-    fputs(" --ipinfo-city              display city\n", out);
-    fputs(" --ipinfo-carrier           display carrier\n", out);
-    fputs(" --ipinfo-geo               display geo\n", out);
-    fputs(" --ipinfo-dns DOMAIN_NAME   Specify DOMAIN_NAME to query DNS data\n", out);
-    fputs(" -z, --aslookup             display AS number\n", out);
+    fputs(" -y, --ipinfo NUMBER,……         select IP information(NUMBER:0~7) in output\n", out);
+    fputs("                                <NUMBER 0: AS number>\n", out);
+    fputs("                                <NUMBER 1: IP prefix>\n", out);
+    fputs("                                <NUMBER 2: country code>\n", out);
+    fputs("                                <NUMBER 3: registry>\n", out);
+    fputs("                                <NUMBER 4: allocation date>\n", out);
+    fputs("                                <NUMBER 5: city>\n", out);
+    fputs("                                <NUMBER 6: carrier>\n", out);
+    fputs("                                <NUMBER 7: geo>\n", out);
+    fputs("     --ipinfo-asn               display AS number, equal to -y 0\n", out);
+    fputs("     --ipinfo-ip-prefix         display IP prefix, equal to -y 1\n", out);
+    fputs("     --ipinfo-country           display country code, equal to -y 2\n", out);
+    fputs("     --ipinfo-register          display registry, equal to -y 3\n", out);
+    fputs("     --ipinfo-date              display allocation date, equal to -y 4\n", out);
+    fputs("     --ipinfo-city              display city, equal to -y 5\n", out);
+    fputs("     --ipinfo-carrier           display carrier, equal to -y 6\n", out);
+    fputs("     --ipinfo-geo               display geo, equal to -y 7\n", out);
+    fputs("     --ipinfo-dns DOMAIN_NAME   Specify DOMAIN_NAME to query DNS data\n", out);
+    fputs(" -z, --aslookup                 display AS number\n", out);
 #endif
-    fputs(" -h, --help                 display this help and exit\n", out);
+    fputs(" -h, --help                     display this help and exit\n", out);
     fputs
-        (" -v, --version              output version information and exit\n",
+        (" -v, --version                  output version information and exit\n",
          out);
     fputs("\n", out);
     fputs("See the 'man 8 mtr' for details.\n", out);
@@ -626,6 +633,8 @@ static void parse_arg(
             if (strlen(optarg) > MAXFLD) {
                 error(EXIT_FAILURE, 0, "Too many fields: %s", optarg);
             }
+            /* Filter out the ipinfo fields, which will be regenerated after
+               this function and added to the front of ctl->fld_active.*/
             for (i = 0, j = 0; optarg[i]; i++) {
                 if (is_ipinfo_filed(optarg[i])) {
                     ctl->ipinfo_arr |= (1 << ipinfo_key2no(optarg[i]));
@@ -722,7 +731,7 @@ static void parse_arg(
             process_ipinfo_arr(ctl, optarg);
             break;
         case 'z':
-            ctl->ipinfo_arr = (1 << ASN);
+            ctl->ipinfo_arr |= (1 << ASN);
             break;
         case OPT_ASN:
             ctl->ipinfo_arr |= (1 << ASN);
@@ -941,6 +950,7 @@ int main(
     if (!IS_CLEAR_IPINFO(ctl.ipinfo_arr)) {
         ctl.ipinfo_no = (int)log2(ctl.ipinfo_arr & (0 - ctl.ipinfo_arr));
     }
+    // use ctl.ipinfo_arr to fill up ctl.fld_active
     for (int i = 0, j = 0; i < IPINFO_NUMS; i++) {
         if (IS_INDEX_IPINFO(ctl.ipinfo_arr, i)) {
             switch (i) {

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -898,6 +898,7 @@ int main(
     char ipinfo_fld[2 * MAXFLD] = {0};
     names_t *names_head = NULL;
     names_t *names_walk;
+    int i, j;
 
     myname = argv[0];
     struct mtr_ctl ctl;
@@ -951,7 +952,7 @@ int main(
         ctl.ipinfo_no = (int)log2(ctl.ipinfo_arr & (0 - ctl.ipinfo_arr));
     }
     // use ctl.ipinfo_arr to fill up ctl.fld_active
-    for (int i = 0, j = 0; i < IPINFO_NUMS; i++) {
+    for (i = 0, j = 0; i < IPINFO_NUMS; i++) {
         if (IS_INDEX_IPINFO(ctl.ipinfo_arr, i)) {
             switch (i) {
                 case ASN:          ipinfo_fld[j++] = 'Z'; break;

--- a/ui/mtr.h
+++ b/ui/mtr.h
@@ -125,7 +125,7 @@ struct fields {
     const char *format;
     const int length;
     int (*net_xxx) (int);
-    char *(*ipinfo_xxx) (struct mtr_ctl *, ip_t *, int);
+    char *(*ipinfo_xxx) (struct mtr_ctl *, ip_t *, int, int);
 };
 /* defined in mtr.c */
 extern const struct fields data_fields[MAXFLD];

--- a/ui/report.c
+++ b/ui/report.c
@@ -149,10 +149,7 @@ void report_close(
 #ifdef HAVE_IPINFO
         if (is_printii(ctl)) {
             snprintf(buf, sizeof(buf), " %2d. ", at + 1);
-            for (i = 0; i < IPINFO_NUMS; i++) {
-                if (IS_INDEX_IPINFO(ctl->ipinfo_arr, i))
-                    snprintf(buf+strlen(buf), sizeof(buf)-strlen(buf), "%s", ipinfo_get_content(ctl, addr, i));
-            }
+            get_ipinfo_compose(ctl, addr, buf, sizeof(buf), at+1);
             snprintf(fmt, sizeof(fmt), "%%-%zus", len_hosts);
             snprintf(buf+strlen(buf), sizeof(buf)-strlen(buf), fmt, name);
         } else {
@@ -289,29 +286,10 @@ void json_close(
     int i, j, at, first, max;
     ip_t *addr;
     char name[MAX_FORMAT_STR];
+    unsigned char key;
+    char *content;
 
     printf("{\n");
-    printf("  \"report\": {\n");
-    printf("    \"mtr\": {\n");
-    printf("      \"src\": \"%s\",\n", ctl->LocalHostname);
-    printf("      \"dst\": \"%s\",\n", ctl->Hostname);
-    printf("      \"tos\": \"0x%X\",\n", ctl->tos);
-    if (ctl->cpacketsize >= 0) {
-        printf("      \"psize\": \"%d\",\n", ctl->cpacketsize);
-    } else {
-        printf("      \"psize\": \"rand(%d-%d)\",\n", MINPACKET,
-               -ctl->cpacketsize);
-    }
-    if (ctl->bitpattern >= 0) {
-        printf("      \"bitpattern\": \"0x%02X\",\n",
-               (unsigned char) (ctl->bitpattern));
-    } else {
-        printf("      \"bitpattern\": \"rand(0x00-FF)\",\n");
-    }
-    printf("      \"tests\": \"%d\"\n", ctl->MaxPing);
-    printf("    },\n");
-
-    printf("    \"hubs\": [");
 
     max = net_max(ctl);
     at = first = net_min(ctl);
@@ -319,30 +297,30 @@ void json_close(
         addr = net_addr(at);
         snprint_addr(ctl, name, sizeof(name), addr);
 
-        if (at == first) {
-            printf("{\n");
-        } else {
-            printf("    {\n");
-        }
-        printf("      \"count\": \"%d\",\n", at + 1);
-        printf("      \"host\": \"%s\",\n", name);
+        printf("  \"%d\": { ", at+1);
+
+        i = 0;
 #ifdef HAVE_IPINFO
-        if(!ctl->ipinfo_no) {
-          char* fmtinfo = fmt_ipinfo(ctl, addr);
-          if (fmtinfo != NULL) fmtinfo = trim(fmtinfo, '\0');
-          printf("      \"ASN\": \"%s\",\n", fmtinfo);
+        for (; i < MAXFLD; i++) {
+            j = ctl->fld_index[ctl->fld_active[i]];
+    		key = data_fields[j].key;
+    		if (!is_ipinfo_filed(key))
+    			break;
+            content = data_fields[j].ipinfo_xxx(ctl, addr, ipinfo_key2no(key), at+1);
+            printf("\"%s\": \"%s\", ", data_fields[j].title, trim(content, ' '));
         }
 #endif
-        for (i = 0; i < MAXFLD; i++) {
+
+        printf("\"HOST\": \"%s\"", name);
+
+        for (; i < MAXFLD; i++) {
             const char *format;
 
             j = ctl->fld_index[ctl->fld_active[i]];
 
             /* Commas */
-            if (i + 1 == MAXFLD) {
-                printf("\n");
-            } else if (j > 0 && i != 0) {
-                printf(",\n");
+            if ((i + 1 != MAXFLD) && j > 0) {
+                printf(", ");
             }
 
             if (j <= 0)
@@ -357,7 +335,7 @@ void json_close(
             }
 
             /* Format json line */
-            snprintf(name, sizeof(name), "%s%s", "      \"%s\": ", format);
+            snprintf(name, sizeof(name), "%s%s", "\"%s\": ", format);
 
             /* Output json line */
             if (strchr(data_fields[j].format, 'f')) {
@@ -370,14 +348,14 @@ void json_close(
                        data_fields[j].title, data_fields[j].net_xxx(at));
             }
         }
+
+
         if (at + 1 == max) {
-            printf("    }");
+            printf("  }\n");
         } else {
-            printf("    },\n");
+            printf("  },\n");
         }
     }
-    printf("]\n");
-    printf("  }\n");
     printf("}\n");
 }
 
@@ -395,6 +373,9 @@ void xml_close(
     int i, j, at, max;
     ip_t *addr;
     char name[MAX_FORMAT_STR];
+    char content_tmp[128];
+    unsigned char key;
+    char *content;
 
     printf("<?xml version=\"1.0\"?>\n");
     printf("<MTR SRC=\"%s\" DST=\"%s\"", ctl->LocalHostname,
@@ -416,19 +397,36 @@ void xml_close(
     max = net_max(ctl);
     at = net_min(ctl);
     for (; at < max; at++) {
-        addr = net_addr(at);
-        snprint_addr(ctl, name, sizeof(name), addr);
+        printf("    <HUB COUNT=\"%d\"> ", at + 1);
 
-        printf("    <HUB COUNT=\"%d\" HOST=\"%s\">\n", at + 1, name);
-        for (i = 0; i < MAXFLD; i++) {
+        addr = net_addr(at);
+        i = 0;
+#ifdef HAVE_IPINFO
+        for (; i < MAXFLD; i++) {
+            j = ctl->fld_index[ctl->fld_active[i]];
+            key = data_fields[j].key;
+            if (!is_ipinfo_filed(key))
+                break;
+            snprintf(name, sizeof(name), "%s%%s%s", "<%s>", "</%s> ");
+            content = data_fields[j].ipinfo_xxx(ctl, addr, ipinfo_key2no(key), at+1);
+            snprintf(content_tmp, sizeof(content_tmp), data_fields[j].format,
+                    content);
+            printf(name, data_fields[j].title, trim(content_tmp, ' '),
+                    data_fields[j].title);
+        }
+#endif
+
+        snprint_addr(ctl, name, sizeof(name), addr);
+        printf("<HOST>%s</HOST> ", name);
+
+        for (; i < MAXFLD; i++) {
             const char *title;
 
             j = ctl->fld_index[ctl->fld_active[i]];
             if (j <= 0)
                 continue;       /* Field nr 0, " " shouldn't be printed in this method. */
 
-            snprintf(name, sizeof(name), "%s%s%s", "        <%s>",
-                     data_fields[j].format, "</%s>\n");
+            snprintf(name, sizeof(name), "%s%%s%s", "<%s>", "</%s> ");
 
             /* XML doesn't allow "%" in tag names, rename Loss% to just Loss */
             title = data_fields[j].title;
@@ -438,13 +436,15 @@ void xml_close(
 
             /* 1000.0 is a temporay hack for stats usec to ms, impacted net_loss. */
             if (strchr(data_fields[j].format, 'f')) {
-                printf(name,
-                       title, data_fields[j].net_xxx(at) / 1000.0, title);
+                snprintf(content_tmp, sizeof(content_tmp), data_fields[j].format,
+                        data_fields[j].net_xxx(at) / 1000.0);
             } else {
-                printf(name, title, data_fields[j].net_xxx(at), title);
+                snprintf(content_tmp, sizeof(content_tmp), data_fields[j].format,
+                        data_fields[j].net_xxx(at));
             }
+            printf(name, title, trim(content_tmp, ' '), title);
         }
-        printf("    </HUB>\n");
+        printf("</HUB>\n");
     }
     printf("</MTR>\n");
 }
@@ -460,8 +460,10 @@ void csv_close(
     time_t now)
 {
     int i, j, at, max;
-    ip_t *addr;
     char name[MAX_FORMAT_STR];
+    unsigned char key;
+    char *content;
+    ip_t *addr;
 
     for (i = 0; i < MAXFLD; i++) {
         j = ctl->fld_index[ctl->fld_active[i]];
@@ -475,34 +477,48 @@ void csv_close(
         addr = net_addr(at);
         snprint_addr(ctl, name, sizeof(name), addr);
 
+        i = 0;
         if (at == net_min(ctl)) {
-            printf("Mtr_Version,Start_Time,Status,Host,Hop,Ip,");
+            printf("Mtr_Version,Start_Time,Status,Host,Hop");
 #ifdef HAVE_IPINFO
-            if (!ctl->ipinfo_no) {
-                printf("Asn,");
+            for (; i < MAXFLD; i++) {
+                j = ctl->fld_index[ctl->fld_active[i]];
+                if (!is_ipinfo_filed(data_fields[j].key))
+        		    break;
+                printf(",%s", data_fields[j].title);
             }
 #endif
-            for (i = 0; i < MAXFLD; i++) {
+            printf(",HOST");
+            for (; i < MAXFLD; i++) {
                 j = ctl->fld_index[ctl->fld_active[i]];
                 if (j < 0)
                     continue;
-                printf("%s,", data_fields[j].title);
+                printf(",%s", data_fields[j].title);
             }
             printf("\n");
         }
+
+        i = 0;
 #ifdef HAVE_IPINFO
-        if (!ctl->ipinfo_no) {
-            char *fmtinfo = fmt_ipinfo(ctl, addr);
-            fmtinfo = trim(fmtinfo, '\0');
-            printf("MTR.%s,%lld,%s,%s,%d,%s,%s", PACKAGE_VERSION,
-                   (long long) now, "OK", ctl->Hostname, at + 1, name,
-                   fmtinfo);
+        if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
+            printf("MTR.%s,%lld,%s,%s,%d", PACKAGE_VERSION,
+                   (long long) now, "OK", ctl->Hostname, at + 1);
+            for (; i < MAXFLD; i++) {
+                j = ctl->fld_index[ctl->fld_active[i]];
+                key = data_fields[j].key;
+                if (!is_ipinfo_filed(key))
+        		    break;
+                content = data_fields[j].ipinfo_xxx(ctl, addr, ipinfo_key2no(key), at+1);
+                printf(",%s", trim(content, ' '));
+            }
         } else
 #endif
-            printf("MTR.%s,%lld,%s,%s,%d,%s", PACKAGE_VERSION,
-                   (long long) now, "OK", ctl->Hostname, at + 1, name);
+            printf("MTR.%s,%lld,%s,%s,%d", PACKAGE_VERSION,
+                   (long long) now, "OK", ctl->Hostname, at + 1);
 
-        for (i = 0; i < MAXFLD; i++) {
+        printf(",%s", name);
+
+        for (; i < MAXFLD; i++) {
             j = ctl->fld_index[ctl->fld_active[i]];
             if (j < 0)
                 continue;


### PR DESCRIPTION
For the common private network address segment (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 and 100.64.0.0/16), no DNS TXT query is sent. However, the query is still sent to the two segments of 10.96.0.0/17 and 10.127.0.0/16 when specifying --ipinfo-dns ip.xelerate.ai