### PR TITLE
CEDGE-604 Add --ipinfo-spec-ip option

### DIFF
--- a/man/mtr.8.in
+++ b/man/mtr.8.in
@@ -412,6 +412,9 @@ You can combine this option with other --ipinfo- or -y options.
 .B -\-ipinfo\-dns \fIDOMAIN_NAME
 Specify special DOMAIN_NAME to query the DNS data. The default value for this parameter is origin6.asn.cymru.com .
 .TP
+.B -\-ipinfo\-spec\-ip \fIIP\fR/\fISUBNET-MASK\fR[,\fIIP\fR/\fISUBNET-MASK\fR,...]
+Reserved for Netpas. Specify a part of the private address that still sends a DNS request when encounters such an address.
+.TP
 .B \-z\fR, \fB\-\-aslookup
 Displays the Autonomous System (AS) number alongside each hop.  Equivalent to \fB\-\-ipinfo 0\fR.
 .IP

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -195,6 +195,7 @@ void *wait_loop(
     int nfds;
     fd_set readers, writers;
     ares_channel channel = (ares_channel)arg;
+    struct timeval tv, *tvp;
 
     while (1) {
         if (sigstat == 1)
@@ -211,7 +212,14 @@ void *wait_loop(
                 continue;
             }
         }
-        if (select(nfds, &readers, &writers, NULL, NULL) > 0) {
+
+        if (!iihash) {
+            tvp = ares_timeout(channel, NULL, &tv);
+        } else {
+            tvp = NULL;
+        }
+
+        if (select(nfds, &readers, &writers, NULL, tvp) > 0) {
             ares_process(channel, &readers, &writers);
         }
      }

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -215,6 +215,9 @@ void *wait_loop(
 
         if (!iihash) {
             tvp = ares_timeout(channel, NULL, &tv);
+            if ((tvp->tv_sec == 0) && (tvp->tv_usec == 0)) {
+                tvp->tv_sec += 3;
+            }
         } else {
             tvp = NULL;
         }
@@ -469,7 +472,7 @@ int get_allinuse_iiwidth(
     return width;
 }
 
-char *fmt_ipinfo(
+static char *fmt_ipinfo(
     struct mtr_ctl *ctl,
     ip_t * addr,
     int hops)
@@ -490,13 +493,13 @@ char *fmt_ipinfo(
 
     return fmtinfo;
 }
-
+/*
 int is_printii(
     struct mtr_ctl *ctl)
 {
     return ((ctl->ipinfo_no >= 0) &&
             (ctl->ipinfo_no < ctl->ipinfo_max));
-}
+}*/
 
 /*
  * Get the ipinfo individual field information.

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -61,13 +61,14 @@
 #define DEB_syslog(...) do {} while (0)
 #endif
 
-#define IIHASH_HI   128
-#define ITEMSMAX    15
-#define ITEMSEP '|'
-#define NAMELEN 127
-#define UNKN    "???"
-#define EMPTY   "--"
-#define SEMPATH "sem"
+#define IIHASH_HI       128
+#define ITEMSMAX        15
+#define ITEMSEP         '|'
+#define NAMELEN         127
+#define UNKN            "???"
+#define EMPTY           "--"
+#define SEMPATH         "sem"
+#define NETPAS_DOMAIN  "ip.xelerate.ai"
 
 typedef char *items_t[ITEMSMAX + 1];
 struct comparm {
@@ -85,9 +86,9 @@ static volatile int sigstat = 0;
 /* items width: ASN, Route, Country, Registry, Allocated, City, Carrier, Geo */
 static const int iiwidth[] = {9, 18, 6, 7, 13, 8, 10, 15};   /* item len + space */
 /* used for checking private ip */
-static int prefix_arr[6] = {8, 17, 16, 12, 16, 16};
-static unsigned int mask_ip_scope[6];
-static unsigned int special_ip_scope[6];
+static int prefix_arr[4] = {8, 12, 16, 16};
+static unsigned int mask_ip_scope[4];
+static unsigned int private_ip_scope[4];
 
 #ifdef ENABLE_IPV6
 char ipinfo_domain6[128] = "origin6.asn.cymru.com";
@@ -258,13 +259,12 @@ static void init_private_ip(void)
 {
     int i;
 
-    special_ip_scope[0] = 167772160L;	// 10.0.0.0/8
-	special_ip_scope[1] = 174063616L;	// 10.96.0.0/17
-	special_ip_scope[2] = 176095232L;	// 10.127.0.0/16
-	special_ip_scope[3] = 2886729728L;	// 172.16.0.0/12
-	special_ip_scope[4] = 3232235520L;	// 192.168.0.0/16
-	special_ip_scope[5] = 1681915904L;	// 100.64.0.0/16
-	for (i = 0; i < 6; i++) {
+    // general private ip address
+    private_ip_scope[0] = 167772160L;	// 10.0.0.0/8
+	private_ip_scope[1] = 2886729728L;	// 172.16.0.0/12
+	private_ip_scope[2] = 3232235520L;	// 192.168.0.0/16
+	private_ip_scope[3] = 1681915904L;	// 100.64.0.0/16
+	for (i = 0; i < 4; i++) {
 		mask_ip_scope[i] = 0xffffffff;
 		mask_ip_scope[i] <<= (32 - prefix_arr[i]);
 		mask_ip_scope[i] &= 0xffffffff;
@@ -281,14 +281,10 @@ static int is_private_ip(ip_t *addr)
     }
 
     ipaddr = htonl((*(struct in_addr *)addr).s_addr);
-	for (i = 3; i < 6; i++) {
-		if ((ipaddr & mask_ip_scope[i]) == special_ip_scope[i])
+
+	for (i = 0; i < 4; i++) {
+		if ((ipaddr & mask_ip_scope[i]) == private_ip_scope[i])
 			return 1;
-	}
-	if ((ipaddr & mask_ip_scope[0]) == special_ip_scope[0]) {
-		if (!((ipaddr & mask_ip_scope[1]) == special_ip_scope[1]) &&
-		    !((ipaddr & mask_ip_scope[2]) == special_ip_scope[2]))
-		    return 1;
 	}
 
 	return 0;
@@ -328,9 +324,15 @@ static char *get_ipinfo(
             (key, NAMELEN, "%d.%d.%d.%d", buff[3], buff[2], buff[1],
              buff[0]) >= NAMELEN)
             return NULL;
-        if (snprintf(lookup_key, NAMELEN, "%d.mtr.%s.%s", hops, key, ipinfo_domain)
-            >= NAMELEN)
-            return NULL;
+        if (strcmp(ipinfo_domain, NETPAS_DOMAIN) == 0) {
+            if (snprintf(lookup_key, NAMELEN, "%d.mtr.%s.%s", hops, key,
+                    ipinfo_domain) >= NAMELEN)
+                return NULL;
+        } else {
+            if (snprintf(lookup_key, NAMELEN, "%s.%s", key, ipinfo_domain)
+                     >= NAMELEN)
+                return NULL;
+        }
     }
 
     if (iihash) {

--- a/ui/asn.c
+++ b/ui/asn.c
@@ -65,10 +65,11 @@
 #define ITEMSMAX        15
 #define ITEMSEP         '|'
 #define NAMELEN         127
+#define SPECIP_MAX      10
 #define UNKN            "???"
 #define EMPTY           "--"
 #define SEMPATH         "sem"
-#define NETPAS_DOMAIN  "ip.xelerate.ai"
+#define NETPAS_DOMAIN   "ip.xelerate.ai"
 
 typedef char *items_t[ITEMSMAX + 1];
 struct comparm {
@@ -89,6 +90,10 @@ static const int iiwidth[] = {9, 18, 6, 7, 13, 8, 10, 15};   /* item len + space
 static int prefix_arr[4] = {8, 12, 16, 16};
 static unsigned int mask_ip_scope[4];
 static unsigned int private_ip_scope[4];
+/* used for specific ip segment in private ip */
+static int spec_prefix_arr[SPECIP_MAX];
+static unsigned int spec_mask_ip_scope[SPECIP_MAX];
+static unsigned int spec_ip_scope[SPECIP_MAX];
 
 #ifdef ENABLE_IPV6
 char ipinfo_domain6[128] = "origin6.asn.cymru.com";
@@ -255,6 +260,41 @@ static void reverse_host6(
 }
 #endif
 
+void process_ip_prefix(char *ipprefix)
+{
+    char *p = NULL;
+    static int index = 0;
+
+    if (index >= (sizeof(spec_prefix_arr)/sizeof(spec_prefix_arr[0])))
+        return;
+
+    p = strrchr(ipprefix, '/');
+    if (p == NULL) {
+        error(EXIT_FAILURE, 0, "invalid argument:%s", ipprefix);
+    }
+    *p++ = '\0';
+
+    spec_prefix_arr[index] = strtonum_or_err(p, "invalid argument", STRTO_INT);
+    if (spec_prefix_arr[index] <= 0 || spec_prefix_arr[index] >= 32) {
+        *(--p) = '/';
+        error(EXIT_FAILURE, 0, "invalid argument:%s", ipprefix);
+    }
+
+    spec_mask_ip_scope[index] = 0xffffffff;
+    spec_mask_ip_scope[index] <<= (32 - spec_prefix_arr[index]);
+    spec_mask_ip_scope[index] &= 0xffffffff;
+
+    spec_ip_scope[index] = inet_addr(ipprefix);
+    if (spec_ip_scope[index] == INADDR_NONE) {
+        *(--p) = '/';
+        error(EXIT_FAILURE, 0, "invalid argument:%s", ipprefix);
+    }
+    spec_ip_scope[index] = htonl(spec_ip_scope[index]);
+    spec_ip_scope[index] &= spec_mask_ip_scope[index];
+
+    index++;
+}
+
 static void init_private_ip(void)
 {
     int i;
@@ -281,6 +321,15 @@ static int is_private_ip(ip_t *addr)
     }
 
     ipaddr = htonl((*(struct in_addr *)addr).s_addr);
+
+    if (strcmp(ipinfo_domain, NETPAS_DOMAIN) == 0) {
+        i = 0;
+        while (spec_prefix_arr[i] != 0) {
+            if ((ipaddr & spec_mask_ip_scope[i]) == spec_ip_scope[i])
+                return 0;
+            i++;
+        }
+    }
 
 	for (i = 0; i < 4; i++) {
 		if ((ipaddr & mask_ip_scope[i]) == private_ip_scope[i])

--- a/ui/asn.h
+++ b/ui/asn.h
@@ -58,3 +58,5 @@ extern int get_ipinfo_compose(
     char *buf,
     int buflen,
     int hops);
+extern void process_ip_prefix(
+    char *ipprefix);

--- a/ui/asn.h
+++ b/ui/asn.h
@@ -35,18 +35,14 @@ extern void asn_open(
     struct mtr_ctl *ctl);
 extern void asn_close(
     struct mtr_ctl *ctl);
-extern char *fmt_ipinfo(
-    struct mtr_ctl *ctl,
-    ip_t * addr,
-    int hops);
 extern ATTRIBUTE_CONST size_t get_iiwidth_len(
     void);
 extern ATTRIBUTE_CONST int get_iiwidth(
     int ipinfo_no);
 extern int get_allinuse_iiwidth(
         struct mtr_ctl *ctl);
-extern int is_printii(
-    struct mtr_ctl *ctl);
+/*extern int is_printii(
+    struct mtr_ctl *ctl);*/
 extern char *ipinfo_get_content(
     struct mtr_ctl *ctl,
     ip_t * addr,

--- a/ui/gtk.c
+++ b/ui/gtk.c
@@ -398,7 +398,7 @@ static void TreeViewCreate(
                      G_CALLBACK(ReportTreeView_clicked), ctl);
 
 #ifdef HAVE_IPINFO
-    if (is_printii(ctl)) {
+    if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
         renderer = gtk_cell_renderer_text_new();
         column = gtk_tree_view_column_new_with_attributes("ASN",
                                                           renderer,

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -240,6 +240,8 @@ static void __attribute__ ((__noreturn__)) usage(FILE * out)
     fputs("     --ipinfo-carrier           display carrier, equal to -y 6\n", out);
     fputs("     --ipinfo-geo               display geo, equal to -y 7\n", out);
     fputs("     --ipinfo-dns DOMAIN_NAME   Specify DOMAIN_NAME to query DNS data\n", out);
+    fputs("     --ipinfo-spec-ip IP/SUBNET-MASK[,IP/SUBNET-MASK,...]\n"
+          "                                reserved for Netpas\n", out);
     fputs(" -z, --aslookup                 display AS number\n", out);
 #endif
     fputs(" -h, --help                     display this help and exit\n", out);
@@ -397,6 +399,21 @@ static void process_ipinfo_arr(struct mtr_ctl *ctl, char *optarg)
 	}
 }
 
+static void process_specific_ip_segment(char *optarg)
+{
+    char *t;
+
+	if (optarg == NULL)
+		return;
+
+	t = strtok(optarg, ",");
+	while (t != NULL) {
+        process_ip_prefix(t);
+
+		t = strtok(NULL, ",");
+	}
+}
+
 static void parse_arg(
     struct mtr_ctl *ctl,
     names_t ** names,
@@ -421,7 +438,8 @@ static void parse_arg(
         OPT_CITY,
         OPT_CARRIER,
         OPT_GEO,
-        OPT_DNS
+        OPT_DNS,
+        OPT_SPECIP
     };
     static const struct option long_options[] = {
         /* option name, has argument, NULL, short name */
@@ -465,6 +483,7 @@ static void parse_arg(
         {"ipinfo-carrier", 0, NULL, OPT_CARRIER},
         {"ipinfo-geo", 0, NULL, OPT_GEO},
         {"ipinfo-dns", 1, NULL, OPT_DNS},
+        {"ipinfo-spec-ip", 1, NULL, OPT_SPECIP},
 #endif
 
         {"interval", 1, NULL, 'i'},
@@ -760,6 +779,11 @@ static void parse_arg(
         case OPT_DNS:
             if (optarg) {
                 strncpy(ipinfo_domain, optarg, sizeof(ipinfo_domain) - 1);
+            }
+            break;
+        case OPT_SPECIP:
+            if (optarg) {
+                process_specific_ip_segment(optarg);
             }
             break;
 #endif

--- a/ui/mtr.c
+++ b/ui/mtr.c
@@ -898,6 +898,7 @@ int main(
     char ipinfo_fld[2 * MAXFLD] = {0};
     names_t *names_head = NULL;
     names_t *names_walk;
+    int i, j;
 
     myname = argv[0];
     struct mtr_ctl ctl;
@@ -951,7 +952,7 @@ int main(
         ctl.ipinfo_no = (int)log2(ctl.ipinfo_arr & (0 - ctl.ipinfo_arr));
     }
     // use ctl.ipinfo_arr to fill up ctl.fld_active
-    for (int i = 0, j = 0; i < IPINFO_NUMS; i++) {
+    for (i = 0, j = 0; i < IPINFO_NUMS; i++) {
         if (IS_INDEX_IPINFO(ctl.ipinfo_arr, i)) {
             switch (i) {
                 case ASN:          ipinfo_fld[j++] = 'Z'; break;

--- a/ui/report.c
+++ b/ui/report.c
@@ -147,9 +147,10 @@ void report_close(
         snprint_addr(ctl, name, sizeof(name), addr);
 
 #ifdef HAVE_IPINFO
-        if (is_printii(ctl)) {
+        if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
             snprintf(buf, sizeof(buf), " %2d. ", at + 1);
-            get_ipinfo_compose(ctl, addr, buf, sizeof(buf), at+1);
+            get_ipinfo_compose(ctl, addr, buf + strlen(buf),
+                                sizeof(buf) - strlen(buf), at + 1);
             snprintf(fmt, sizeof(fmt), "%%-%zus", len_hosts);
             snprintf(buf+strlen(buf), sizeof(buf)-strlen(buf), fmt, name);
         } else {
@@ -201,7 +202,7 @@ void report_close(
             if (!found) {
 
 #ifdef HAVE_IPINFO
-                if (is_printii(ctl)) {
+                if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
                     if (mpls->labels && z == 1 && ctl->enablempls)
                         print_mpls(mpls);
                     snprint_addr(ctl, name, sizeof(name), addr2);
@@ -243,7 +244,7 @@ void report_close(
 
         /* No multipath */
 #ifdef HAVE_IPINFO
-        if (is_printii(ctl)) {
+        if (!IS_CLEAR_IPINFO(ctl->ipinfo_arr)) {
             if (mpls->labels && z == 1 && ctl->enablempls)
                 print_mpls(mpls);
         }


### PR DESCRIPTION
--ipinfo-spec-ip ip/subnet-mask[,ip/subnet-mask,... ]
specifying that a part of the private IP address segment can send ipinfo DNS requests. Reserved for Netpas.